### PR TITLE
Чтобы тестировать мой и Ленин клиент, нужно делать кросс-доменные запросы.

### DIFF
--- a/server/Dispatcher.pm
+++ b/server/Dispatcher.pm
@@ -27,6 +27,8 @@ sub handler {
   my $r = Apache2::Request->new($rr);
 
   $rr->content_type('text/plain; charset="utf-8"');
+  $rr->headers_out()->{'Access-Control-Allow-Origin'} = "*";
+
   getServer()->process($r);
 
   return Apache2::Const::OK;


### PR DESCRIPTION
To allow cross-domain request modern browsers require existence of Access-Control-Allow-Origin header in response from server. Allowed values to this header are: \* or space-separated list of domains(see
http://www.w3.org/TR/2008/WD-access-control-20080912/#access-control-allow-origin or http://msdn.microsoft.com/en-us/library/ie/cc288060%28v=vs.85%29.aspx for IE).
